### PR TITLE
fix: pull token from collectedTokens on transfer

### DIFF
--- a/server/controllers/CreateAndMintToken.js
+++ b/server/controllers/CreateAndMintToken.js
@@ -77,6 +77,7 @@ export const createCollectionAndTokenController = async (req, res) => {
     const createToken = await TokenModel.create({
       tokenName,
       tokenId,
+      collectionId,
       tokenOwnerAddress: address,
       tokenOwnerId: user._id,
       tokenDescription,
@@ -158,6 +159,7 @@ export const mintToken = async (req, res) => {
       const mintToken = await TokenModel.create({
         tokenName,
         tokenId,
+        collectionId,
         tokenOwnerAddress: address,
         tokenOwnerId: user._id,
         tokenDescription,

--- a/server/models/TokenModel.js
+++ b/server/models/TokenModel.js
@@ -2,6 +2,7 @@ import mongoose from "mongoose";
 
 const TokenSchema = new mongoose.Schema({
   tokenId: String,
+  collectionId: Number,
   tokenName: String,
   tokenOwnerAddress: String,
   tokenOwnerId: {


### PR DESCRIPTION
@tarzann419 
This is just a fix of what we talked about yesterday.
If the token is a winning token and the sender transfers, it removes it from the user's collectedTokens list